### PR TITLE
docs: add markdown plugin to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ This repo is the web editor of Papyrs. It can be used as a standalone app but us
 - [Stylo](https://github.com/papyrs/stylo): another kind of rich text editor
 - [Kit](https://github.com/papyrs/kit): the templates for the blog posts we deploy for the users
 - [DeckDeckGo](https://github.com/deckgo/deckdeckgo/): various web components, utilities and the providers for the offline persistence and synchronization of the data
+
+Other handy tools:
 - [Papyrs to markdown](https://chrome.google.com/webstore/detail/papyrs-to-markdown/caacmbgdcjpdpmccocmbiljodkbkjglh): Chrome markdown-plugin that can be used to convert a blog post to markdown
 
 ## Architecture overview

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ This repo is the web editor of Papyrs. It can be used as a standalone app but us
 - [Stylo](https://github.com/papyrs/stylo): another kind of rich text editor
 - [Kit](https://github.com/papyrs/kit): the templates for the blog posts we deploy for the users
 - [DeckDeckGo](https://github.com/deckgo/deckdeckgo/): various web components, utilities and the providers for the offline persistence and synchronization of the data
+- [Papyrs to markdown](https://chrome.google.com/webstore/detail/papyrs-to-markdown/caacmbgdcjpdpmccocmbiljodkbkjglh): Chrome markdown-plugin that can be used to convert a blog post to markdown
 
 ## Architecture overview
 


### PR DESCRIPTION
gh - #11 
I have added a link to `Chrome markdown-plugin` in `README.md` as stated in the issue.