### PR TITLE
style: break-word for any elements

### DIFF
--- a/src/lib/themes/mixins/_doc.scss
+++ b/src/lib/themes/mixins/_doc.scss
@@ -100,7 +100,7 @@
     overflow-x: auto;
   }
 
-  span {
+  * {
     word-break: break-word;
   }
 }


### PR DESCRIPTION
Not just `span` can contains long URL copied as text but also `div` or `li` or just text node.

Replicated in kit in commit [e1f997d](https://github.com/papyrs/kit/commit/e1f997d0c35b98e9e38a0b69869a1802b8d5f13b) 